### PR TITLE
Bitnami moved back to docker hub

### DIFF
--- a/sealed-secret.tf
+++ b/sealed-secret.tf
@@ -58,7 +58,7 @@ resource "helm_release" "sealed_secrets" {
 
   set {
     name  = "image.repository"
-    value = "quay.io/bitnami/sealed-secrets-controller"
+    value = "bitnami/sealed-secrets-controller"
   }
 
   set {


### PR DESCRIPTION
Bitnami moved back to docker hub.
Signed-off-by: Travis Stevens <travis.stevens@urjanet.com>